### PR TITLE
Fix outdated download URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,49 @@ if (new File(projectDir, '.git').exists()) {
     gitHash = repo.log().find().abbreviatedId
 }
 
+// Workaround for outdated Mojang URLs in ForgeGradle 1.2
+// Pre-download the required client JAR and version JSON from modern hosts
+// and disable the original download tasks that point to removed endpoints
+def mcJarUrl = 'https://launcher.mojang.com/v1/objects/e80d9b3bf5085002218d4be59e668bac718abbc6/client.jar'
+def mcJsonUrl = 'https://piston-meta.mojang.com/v1/packages/ed5d8789ed29872ea2ef1c348302b0c55e3f3468/1.7.10.json'
+def mcServerUrl = 'https://launcher.mojang.com/v1/objects/952438ac4e01b4d115c5fc38f891710c4941df29/server.jar'
+
+gradle.afterProject { proj ->
+    tasks.matching { it.name == 'downloadClient' }.all { t ->
+        t.doFirst {
+            def dest = new File(gradle.gradleUserHomeDir,
+                "caches/minecraft/net/minecraft/minecraft/${proj.mc_version}/minecraft-${proj.mc_version}.jar")
+            if (!dest.exists()) {
+                dest.parentFile.mkdirs()
+                new URL(mcJarUrl).withInputStream { i -> dest.withOutputStream { it << i } }
+            }
+        }
+        t.enabled = false
+    }
+    tasks.matching { it.name == 'downloadServer' }.all { t ->
+        t.doFirst {
+            def dest = new File(gradle.gradleUserHomeDir,
+                "caches/minecraft/net/minecraft/minecraft_server/${proj.mc_version}/minecraft_server-${proj.mc_version}.jar")
+            if (!dest.exists()) {
+                dest.parentFile.mkdirs()
+                new URL(mcServerUrl).withInputStream { i -> dest.withOutputStream { it << i } }
+            }
+        }
+        t.enabled = false
+    }
+    tasks.matching { it.name == 'getVersionJson' }.all { t ->
+        t.doFirst {
+            def dest = new File(gradle.gradleUserHomeDir,
+                "caches/minecraft/versionJsons/${proj.mc_version}.json")
+            if (!dest.exists()) {
+                dest.parentFile.mkdirs()
+                new URL(mcJsonUrl).withInputStream { i -> dest.withOutputStream { it << i } }
+            }
+        }
+        t.enabled = false
+    }
+}
+
 repositories {
     maven { url "https://mobiusstrip.eu/maven"} // Waila
 	maven { url "https://chickenbones.net/maven/" } // NEI


### PR DESCRIPTION
## Summary
- override Mojang download tasks so Gradle pulls jars from current URLs
- disable ForgeGradle's built‑in download steps

## Testing
- `./gradlew build` *(fails: Could not resolve dependencies, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840b9a4d0ec8321af3122debf85882e