### PR TITLE
Fix Java heap errors during build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,5 @@ forge_version=10.13.2.1291
 waila_version=1.5.10
 
 mod_version=1.1.2
+
+org.gradle.jvmargs=-Xmx2G


### PR DESCRIPTION
## Summary
- allocate more memory to Gradle

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6840bfe0c5d48321a18418eb91c882a4