### PR TITLE
Fix compile warnings and target Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,8 @@ tasks.build.dependsOn sourceJar, javadocJar, deobfJar
 
 tasks.withType(JavaCompile) { task ->
     task.options.encoding = 'UTF-8'
+    task.sourceCompatibility = '1.8'
+    task.targetCompatibility = '1.8'
 }
 
 publishing {

--- a/src/main/java/com/whammich/invasion/client/render/RenderB.java
+++ b/src/main/java/com/whammich/invasion/client/render/RenderB.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderLiving;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Vec3;
 import org.lwjgl.opengl.GL11;
@@ -28,8 +29,9 @@ public class RenderB extends RenderLiving {
         super.doRender(entityBird, renderX, renderY, renderZ, interpYaw, partialTick);
     }
 
-    public void doRender(Entity entity, double d, double d1, double d2, float f, float f1) {
-        renderBz((EntityIMBird) entity, d, d1, d2, f, f1);
+    @Override
+    public void doRender(EntityLiving entity, double x, double y, double z, float yaw, float partialTick) {
+        renderBz((EntityIMBird) entity, x, y, z, yaw, partialTick);
     }
 
     private void renderNavigationVector(EntityIMBird entityBird, double entityRenderOffsetX, double entityRenderOffsetY, double entityRenderOffsetZ) {

--- a/src/main/java/com/whammich/invasion/client/render/RenderGiantBird.java
+++ b/src/main/java/com/whammich/invasion/client/render/RenderGiantBird.java
@@ -34,8 +34,9 @@ public class RenderGiantBird extends RenderIMLiving {
         super.doRenderLiving(entityBird, renderX, renderY, renderZ, interpYaw, partialTick);
     }
 
-    public void doRender(Entity entity, double d, double d1, double d2, float f, float f1) {
-        renderGiantBird((EntityIMBird) entity, d, d1, d2, f, f1);
+    @Override
+    public void doRender(EntityLiving entity, double x, double y, double z, float yaw, float partialTick) {
+        renderGiantBird((EntityIMBird) entity, x, y, z, yaw, partialTick);
     }
 
     protected void renderModel(EntityLiving par1EntityLiving, float par2, float par3, float par4, float par5, float par6, float par7) {

--- a/src/main/java/com/whammich/invasion/client/render/RenderIMWolf.java
+++ b/src/main/java/com/whammich/invasion/client/render/RenderIMWolf.java
@@ -4,6 +4,7 @@ import net.minecraft.client.model.ModelWolf;
 import net.minecraft.client.renderer.entity.RenderWolf;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
@@ -21,7 +22,7 @@ public class RenderIMWolf extends RenderWolf {
     }
 
     @Override
-    protected ResourceLocation getEntityTexture(Entity entity) {
+    protected ResourceLocation getEntityTexture(EntityWolf entity) {
         return wolf;
     }
 }


### PR DESCRIPTION
## Summary
- match Java 8 in Gradle compile settings
- use typed parameters in renderers

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6840c17830688321bfae2c43455dc50a