### PR TITLE
Update for modern Minecraft

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,9 @@ if (new File(projectDir, '.git').exists()) {
 // Workaround for outdated Mojang URLs in ForgeGradle 1.2
 // Pre-download the required client JAR and version JSON from modern hosts
 // and disable the original download tasks that point to removed endpoints
-def mcJarUrl = 'https://launcher.mojang.com/v1/objects/e80d9b3bf5085002218d4be59e668bac718abbc6/client.jar'
-def mcJsonUrl = 'https://piston-meta.mojang.com/v1/packages/ed5d8789ed29872ea2ef1c348302b0c55e3f3468/1.7.10.json'
-def mcServerUrl = 'https://launcher.mojang.com/v1/objects/952438ac4e01b4d115c5fc38f891710c4941df29/server.jar'
+def mcJarUrl = 'https://piston-data.mojang.com/v1/objects/b88808bbb3da8d9f453694b5d8f74a3396f1a533/client.jar'
+def mcJsonUrl = 'https://piston-meta.mojang.com/v1/packages/095b1df74a3ffee4b53fec100abb50d40a42d950/1.21.5.json'
+def mcServerUrl = 'https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar'
 
 gradle.afterProject { proj ->
     tasks.matching { it.name == 'downloadClient' }.all { t ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 mod_name=Invasion
 package_group=com.whammich.invasion
 
-mc_version=1.7.10
-forge_version=10.13.2.1291
+mc_version=1.21.5
+forge_version=51.0.33
 #Uncomment the following line to use MCP Snapshots
 #mappings_version=
 


### PR DESCRIPTION
## Summary
- attempt to update Minecraft version info
- update the pre-download URLs for client/server jars

## Testing
- `./gradlew build` *(fails: ForgeGradle 1.2 does not support forge 51.0.33)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2f40f708321afe8ffd0817cc794